### PR TITLE
Add minimal IntelliJ IDEA entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,31 @@
 solution_33_3_1.dbf
 /data sources/
 *.DS_Store
+
+# Created by https://www.toptal.com/developers/gitignore/api/intellij
+# Edit at https://www.toptal.com/developers/gitignore?templates=intellij
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+### Intellij Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+.idea/misc.xml
+
+# End of https://www.toptal.com/developers/gitignore/api/intellij
+
+# other IDEA files not mentioned explicitly from gitignore.io-generated
+.idea/vcs.xml
+.idea/.name
+.idea/.gitignore


### PR DESCRIPTION
I'm starting to tinker around with this repo and want to exclude files from IntelliJ IDEA Community Edition from being committed.

There may be more entries that are needed later.