### PR TITLE
Insert shapefile interface

### DIFF
--- a/src/main/java/org/nocrala/tools/gis/data/esri/shapefile/ShapeFileReader.java
+++ b/src/main/java/org/nocrala/tools/gis/data/esri/shapefile/ShapeFileReader.java
@@ -20,6 +20,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.util.Arrays;
 
 /**
  * Reads an ESRI Shape File from an InputStream and provides its contents as
@@ -35,32 +36,6 @@ public class ShapeFileReader implements shapefile.ShapeFileReader {
   private boolean eofReached;
 
   // Constructors
-
-  /**
-   * <p>
-   * Reads a Shape File from an InputStream using the default validation
-   * preferences. The default validation preferences conforms strictly to the
-   * ESRI ShapeFile specification.
-   * </p>
-   * 
-   * <p>
-   * The constructor will automatically read the header of the file. Thereafter,
-   * use the method next() to read all shapes.
-   * </p>
-   * 
-   * @param is
-   *          the InputStream to be read.
-   * @throws InvalidShapeFileException
-   *           if the data is malformed, according to the ESRI ShapeFile
-   *           specification.
-   * @throws IOException
-   *           if it's not possible to read from the InputStream.
-   */
-  public ShapeFileReader(final InputStream is)
-      throws InvalidShapeFileException, IOException {
-    ValidationPreferences rules = new ValidationPreferences();
-    initialize(is, rules);
-  }
 
   /**
    * <p>
@@ -117,16 +92,13 @@ public class ShapeFileReader implements shapefile.ShapeFileReader {
       } catch (Exception ex) {
         System.out.println("aobj ex "+ex);
         ex.printStackTrace();
-        for( int i = 0; i < aobj.length; i++) {
-          aobj[i] = "";
-        }
+        Arrays.fill(aobj, "");
 
       }
       switch (s.getShapeType()) {
         case POLYGON_Z:
         {
           int rec_num = s.getHeader().getRecordNumber();
-          //System.out.println("record number: "+rec_num);
           PolygonZShape aPolygon = (PolygonZShape) s;
 
           VTD feature = new VTD();
@@ -137,9 +109,7 @@ public class ShapeFileReader implements shapefile.ShapeFileReader {
           feature.properties.from_shape_file = true;
           for(int i = 0; i < cols.length; i++) {
             feature.properties.put(cols[i],aobj[i].toString());
-            //System.out.print(aobj[i].toString()+" ");
           }
-          //System.out.println();
           feature.properties.post_deserialize();
           feature.geometry.coordinates = new double[aPolygon.getNumberOfParts()][][];
 
@@ -158,7 +128,6 @@ public class ShapeFileReader implements shapefile.ShapeFileReader {
         case POLYGON:
         {
           int rec_num = s.getHeader().getRecordNumber();
-          //System.out.println("record number: "+rec_num);
           PolygonShape aPolygon = (PolygonShape) s;
 
           VTD feature = new VTD();
@@ -169,9 +138,7 @@ public class ShapeFileReader implements shapefile.ShapeFileReader {
           feature.properties.from_shape_file = true;
           for(int i = 0; i < cols.length; i++) {
             feature.properties.put(cols[i],aobj[i].toString());
-            //System.out.print(aobj[i].toString()+" ");
           }
-          //System.out.println();
           feature.properties.post_deserialize();
           feature.geometry.coordinates = new double[aPolygon.getNumberOfParts()][][];
 

--- a/src/main/java/shapefile/NocralaShapeFileReaderFactory.java
+++ b/src/main/java/shapefile/NocralaShapeFileReaderFactory.java
@@ -1,0 +1,20 @@
+package shapefile;
+
+import org.nocrala.tools.gis.data.esri.shapefile.ShapeFileReader;
+import org.nocrala.tools.gis.data.esri.shapefile.ValidationPreferences;
+import org.nocrala.tools.gis.data.esri.shapefile.exception.InvalidShapeFileException;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+public class NocralaShapeFileReaderFactory {
+    public static ShapeFileReader createShapeFileReader(FileInputStream is) throws InvalidShapeFileException, IOException {
+        ValidationPreferences prefs = new ValidationPreferences();
+        prefs.setMaxNumberOfPointsPerShape(32650*4);
+        prefs.setAllowUnlimitedNumberOfPointsPerShape(true);
+        prefs.setAllowBadContentLength(true);
+        prefs.setAllowBadRecordNumbers(true);
+
+        return new ShapeFileReader(is, prefs);
+    }
+}

--- a/src/main/java/shapefile/ShapeFileReader.java
+++ b/src/main/java/shapefile/ShapeFileReader.java
@@ -1,0 +1,14 @@
+package shapefile;
+
+import dbf.DBFReader;
+import geography.FeatureCollection;
+import org.nocrala.tools.gis.data.esri.shapefile.exception.InvalidShapeFileException;
+
+import java.io.IOException;
+
+public interface ShapeFileReader {
+
+    String getHeaderShapeType();
+
+    int processShapeFile(String[] cols, DBFReader dbfreader, FeatureCollection featureCollection) throws InvalidShapeFileException, IOException;
+}

--- a/src/main/java/ui/MainFrame.java
+++ b/src/main/java/ui/MainFrame.java
@@ -3704,8 +3704,7 @@ public class MainFrame extends JFrame implements iChangeListener, iDiscreteEvent
 				System.out.print(cols[i]+"  ");
 			}
 			System.out.print("\n");
-		    
-		    System.out.println("The shape type of this files is " + r.getHeaderShapeType());
+		    System.out.println("The shape type of this file is " + r.getHeaderShapeType());
 
 			int total = r.processShapeFile(cols, dbfreader, featureCollection);
 			for( int i=0; i<cols.length; i++) {
@@ -3713,15 +3712,12 @@ public class MainFrame extends JFrame implements iChangeListener, iDiscreteEvent
 				System.out.print(cols[i]+"  ");
 			}
 			System.out.print("\n");
-
-
 		    System.out.println("Total shapes read: " + total);
 
 		    is.close();		
 		} catch (Exception ex) {
 			System.out.println("exception in processing shapefile: "+ex);
 			ex.printStackTrace();
-			
 		}
 	}
 

--- a/src/main/java/ui/MainFrame.java
+++ b/src/main/java/ui/MainFrame.java
@@ -5,12 +5,12 @@ import geography.Properties;
 import geography.*;
 import new_metrics.Metrics;
 import org.nocrala.tools.gis.data.esri.shapefile.ShapeFileReader;
-import org.nocrala.tools.gis.data.esri.shapefile.ValidationPreferences;
 import org.nocrala.tools.gis.data.esri.shapefile.header.ShapeFileHeader;
 import org.nocrala.tools.gis.data.esri.shapefile.shape.AbstractShape;
 import org.nocrala.tools.gis.data.esri.shapefile.shape.PointData;
 import org.nocrala.tools.gis.data.esri.shapefile.shape.shapes.PolygonShape;
 import org.nocrala.tools.gis.data.esri.shapefile.shape.shapes.PolygonZShape;
+import shapefile.NocralaShapeFileReaderFactory;
 import solutions.*;
 import util.DataAndHeader;
 import util.FileUtil;
@@ -3697,15 +3697,8 @@ public class MainFrame extends JFrame implements iChangeListener, iDiscreteEvent
 
 	    try {
 			FileInputStream is = new FileInputStream(f);
-			ValidationPreferences prefs = new ValidationPreferences();
-		    prefs.setMaxNumberOfPointsPerShape(32650*4);
-		    prefs.setAllowUnlimitedNumberOfPointsPerShape(true);
-		    prefs.setAllowBadContentLength(true);
-		    prefs.setAllowBadRecordNumbers(true);
-		    
-		    //prefs.setMaxNumberOfPointsPerShape(16650);
-		    ShapeFileReader r = new ShapeFileReader(is, prefs);
-		    
+			ShapeFileReader r = NocralaShapeFileReaderFactory.createShapeFileReader(is);
+
 			String dbfname = f.getAbsolutePath();//.getName();
 			dbfname = dbfname.substring(0,dbfname.length()-4)+".dbf";
 			

--- a/src/main/java/ui/MainFrame.java
+++ b/src/main/java/ui/MainFrame.java
@@ -4,13 +4,8 @@ import dbf.DBFReader;
 import geography.Properties;
 import geography.*;
 import new_metrics.Metrics;
-import org.nocrala.tools.gis.data.esri.shapefile.ShapeFileReader;
-import org.nocrala.tools.gis.data.esri.shapefile.header.ShapeFileHeader;
-import org.nocrala.tools.gis.data.esri.shapefile.shape.AbstractShape;
-import org.nocrala.tools.gis.data.esri.shapefile.shape.PointData;
-import org.nocrala.tools.gis.data.esri.shapefile.shape.shapes.PolygonShape;
-import org.nocrala.tools.gis.data.esri.shapefile.shape.shapes.PolygonZShape;
 import shapefile.NocralaShapeFileReaderFactory;
+import shapefile.ShapeFileReader;
 import solutions.*;
 import util.DataAndHeader;
 import util.FileUtil;
@@ -3710,95 +3705,9 @@ public class MainFrame extends JFrame implements iChangeListener, iDiscreteEvent
 			}
 			System.out.print("\n");
 		    
-			
+		    System.out.println("The shape type of this files is " + r.getHeaderShapeType());
 
-		    ShapeFileHeader h = r.getHeader();
-		    System.out.println("The shape type of this files is " + h.getShapeType());
-
-		    int total = 0;
-		    AbstractShape s;
-		    while ((s = r.next()) != null) {
-		    	Object[] aobj = new Object[cols.length];
-		    	try {
-		    		aobj = dbfreader.nextRecord(Charset.defaultCharset());
-		    	} catch (Exception ex) {
-		    		System.out.println("aobj ex "+ex);
-		    		ex.printStackTrace();
-		    		for( int i = 0; i < aobj.length; i++) {
-		    			aobj[i] = "";
-		    		}
-		    		
-		    	}
-		      switch (s.getShapeType()) {
-		      case POLYGON_Z:
-			      {
-			    	  int rec_num = s.getHeader().getRecordNumber();
-			    	  //System.out.println("record number: "+rec_num);
-			          PolygonZShape aPolygon = (PolygonZShape) s;
-			          
-			          VTD feature = new VTD();
-			          featureCollection.features.add(feature);
-			          feature.properties = new Properties();
-			          feature.geometry = new Geometry();
-			          feature.properties.esri_rec_num = rec_num;
-			          feature.properties.from_shape_file = true;
-			          for( int i = 0; i < cols.length; i++) {
-			        	  feature.properties.put(cols[i],aobj[i].toString());
-			        	  //System.out.print(aobj[i].toString()+" ");
-			          }
-			          //System.out.println();
-			          feature.properties.post_deserialize();
-			          feature.geometry.coordinates = new double[aPolygon.getNumberOfParts()][][];
-			          
-			          for (int i = 0; i < aPolygon.getNumberOfParts(); i++) {
-			            PointData[] points = aPolygon.getPointsOfPart(i);
-			            feature.geometry.coordinates[i] = new double[points.length][2];
-			            for( int j = 0; j < points.length; j++) {
-			            	feature.geometry.coordinates[i][j][0] = points[j].getX();
-			            	feature.geometry.coordinates[i][j][1] = points[j].getY();
-			            }
-			          }
-			          feature.geometry.post_deserialize();
-			          feature.post_deserialize();
-			      }
-		          break;
-		      case POLYGON:
-			      {
-			    	  int rec_num = s.getHeader().getRecordNumber();
-			    	  //System.out.println("record number: "+rec_num);
-			          PolygonShape aPolygon = (PolygonShape) s;
-			          
-			          VTD feature = new VTD();
-			          featureCollection.features.add(feature);
-			          feature.properties = new Properties();
-			          feature.geometry = new Geometry();
-			          feature.properties.esri_rec_num = rec_num;
-			          feature.properties.from_shape_file = true;
-			          for( int i = 0; i < cols.length; i++) {
-			        	  feature.properties.put(cols[i],aobj[i].toString());
-			        	  //System.out.print(aobj[i].toString()+" ");
-			          }
-			          //System.out.println();
-			          feature.properties.post_deserialize();
-			          feature.geometry.coordinates = new double[aPolygon.getNumberOfParts()][][];
-			          
-			          for (int i = 0; i < aPolygon.getNumberOfParts(); i++) {
-			            PointData[] points = aPolygon.getPointsOfPart(i);
-			            feature.geometry.coordinates[i] = new double[points.length][2];
-			            for( int j = 0; j < points.length; j++) {
-			            	feature.geometry.coordinates[i][j][0] = points[j].getX();
-			            	feature.geometry.coordinates[i][j][1] = points[j].getY();
-			            }
-			          }
-			          feature.geometry.post_deserialize();
-			          feature.post_deserialize();
-			      }
-		          break;
-		      default:
-		        System.out.println("Read other type of shape.");
-		      }
-		      total++;
-		    }
+			int total = r.processShapeFile(cols, dbfreader, featureCollection);
 			for( int i=0; i<cols.length; i++) {
 				cols[i] = dbfreader.getField(i).name;
 				System.out.print(cols[i]+"  ");


### PR DESCRIPTION
Start decoupling `org.nocrala` from `MainFrame` by moving Nocrala-specific logic out of the former into the `org.nocrala` package.

This decoupling should be done anyway -- `MainFrame` should know nothing about ShapeFile readers -- but it will also put us in a good position to swap in a ShapeFile reader via a Maven dependency.