### PR TITLE
Add a simple UI test

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ The `-Xmx4096M -Xms1024M` arguments tell java to reserve 1GB of memory, and allo
 3. Make a ```bin``` directory here.
 4. Execute `mvn clean compile package exec:java`
 
+## Running Tests
+### From a terminal
+Simply execute `mvn test`.
+### From an IDE
+You may need to add `--add-opens java.base/java.util=ALL-UNNAMED` as program arguments or VM arguments in your run configuration, in order to avoid getting `java.lang.reflect.InaccessibleObjectException`s in the console output.
 
 ## Contributing
 * I won't merge anything that can be abused - that makes it so the program can be used to gerrymander.

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,21 @@
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <!-- dependencies for graphical/integration testing -->
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.25.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-swing-junit</artifactId>
+      <version>3.17.1</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/src/test/java/ui/MainFrameTest.java
+++ b/src/test/java/ui/MainFrameTest.java
@@ -1,0 +1,36 @@
+package ui;
+
+import org.assertj.swing.edt.FailOnThreadViolationRepaintManager;
+import org.assertj.swing.edt.GuiActionRunner;
+import org.assertj.swing.fixture.FrameFixture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MainFrameTest {
+
+    @BeforeAll
+    public static void setUpOnce() {
+        FailOnThreadViolationRepaintManager.install();
+    }
+
+    FrameFixture frame;
+
+    @BeforeEach
+    protected void setUp() {
+        MainFrame mainFrame = GuiActionRunner.execute(MainFrame::new);
+        frame = new FrameFixture(mainFrame);
+        frame.show();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        frame.cleanUp();
+    }
+
+    @Test
+    void applicationDisplaysExpectedTitle() {
+        frame.requireTitle("Automatic Redistricter");
+    }
+}


### PR DESCRIPTION
Add a simple test that the app launches successfully. It launches the app and makes sure that the main app window has the title it expects. Then it quits the app.

## ℹ️ Note
It's not a best practice to run by default any tests that launch the UI, but since the project currently lacks any automated tests, this is the best we can do for now, and slightly decreases the tedium of having to launch the app manually. Eventually, any and all UI tests should probably be annotated with `@Disabled` or something else that suppresses them from running by default.