### PR TITLE
Add some more assertions to basic UI test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,12 @@
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>1.4.2</version>
+      <scope>test</scope>
+    </dependency>
 
     <!-- dependencies for graphical/integration testing -->
     <dependency>

--- a/src/test/java/ui/MainFrameTest.java
+++ b/src/test/java/ui/MainFrameTest.java
@@ -1,5 +1,8 @@
 package ui;
 
+import com.google.common.truth.*;
+import org.assertj.swing.core.BasicComponentFinder;
+import org.assertj.swing.core.ComponentFinder;
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager;
 import org.assertj.swing.edt.GuiActionRunner;
 import org.assertj.swing.fixture.FrameFixture;
@@ -7,6 +10,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import javax.swing.*;
+import java.util.ArrayList;
+
+import static com.google.common.truth.Truth.assertThat;
 
 class MainFrameTest {
 
@@ -30,7 +38,28 @@ class MainFrameTest {
     }
 
     @Test
-    void applicationDisplaysExpectedTitle() {
+    void applicationLaunchesSuccessfully() {
         frame.requireTitle("Automatic Redistricter");
+
+        // verify expected menus are displayed in main application window
+
+        ComponentFinder finder = BasicComponentFinder.finderWithCurrentAwtHierarchy();
+
+        JMenuBar menuBar = finder.findByType(JMenuBar.class);
+
+        JMenu fileMenu = (JMenu) menuBar.getComponent(0);
+        assertThat(fileMenu.getText()).isEqualTo("File");
+
+        JMenu mergeMenu = (JMenu) menuBar.getComponent(1);
+        assertThat(mergeMenu.getText()).isEqualTo("Merge");
+
+        JMenu communitiesOfInterestMenu = (JMenu) menuBar.getComponent(2);
+        assertThat(communitiesOfInterestMenu.getText()).isEqualTo("Communities of interest");
+
+        JMenu mapMenu = (JMenu) menuBar.getComponent(3);
+        assertThat(mapMenu.getText()).isEqualTo("Map");
+
+        JMenu windowsMenu = (JMenu) menuBar.getComponent(4);
+        assertThat(windowsMenu.getText()).isEqualTo("Windows");
     }
 }


### PR DESCRIPTION
This adds an assertion library, [Truth](https://truth.dev/), and adds some assertions to make sure that the main window's menus are displayed.

Again, testing UI is brittle and is not a best practice. I'm just adding them for now because (1) I'm tinkering around with Java Swing automated testing and learning about it, (2) this repo doesn't have any other tests, and (3) we can always `@Disable` the test file so that it doesn't run by default.