### PR TITLE
Test opening an ESRI shapefile

### DIFF
--- a/src/test/java/ui/MainFrameTest.java
+++ b/src/test/java/ui/MainFrameTest.java
@@ -1,27 +1,23 @@
 package ui;
 
-import com.google.common.truth.*;
 import org.assertj.swing.core.BasicComponentFinder;
 import org.assertj.swing.core.ComponentFinder;
-import org.assertj.swing.edt.FailOnThreadViolationRepaintManager;
 import org.assertj.swing.edt.GuiActionRunner;
+import org.assertj.swing.finder.JFileChooserFinder;
 import org.assertj.swing.fixture.FrameFixture;
+import org.assertj.swing.fixture.JFileChooserFixture;
+import org.assertj.swing.fixture.JMenuItemFixture;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.swing.*;
-import java.util.ArrayList;
+import java.io.File;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class MainFrameTest {
-
-    @BeforeAll
-    public static void setUpOnce() {
-        FailOnThreadViolationRepaintManager.install();
-    }
 
     FrameFixture frame;
 
@@ -61,5 +57,23 @@ class MainFrameTest {
 
         JMenu windowsMenu = (JMenu) menuBar.getComponent(4);
         assertThat(windowsMenu.getText()).isEqualTo("Windows");
+
+        // assert that the app can successfully open an ESRI shapefile without throwing any exceptions
+        try {
+            JMenuItem menuItem = fileMenu.getItem(4);
+
+            JMenuItemFixture openEsriShapefileMenuItem = new JMenuItemFixture(frame.robot(), menuItem);
+            openEsriShapefileMenuItem.click();
+
+            JFileChooserFixture fileChooserFixture = JFileChooserFinder.findFileChooser().withTimeout(1000).using(frame.robot());
+            File currentWorkingDirectory = new File(System.getProperty("user.dir"));
+            File sampleDataDirectory = new File(currentWorkingDirectory, "data/sample/delaware");
+            fileChooserFixture.setCurrentDirectory(sampleDataDirectory);
+            fileChooserFixture.selectFile(new File(sampleDataDirectory, "delaware.shp"));
+            fileChooserFixture.approve();
+
+        } catch (Exception e) {
+            fail(e);
+        }
     }
 }


### PR DESCRIPTION
Add a test to make sure that opening an ESRI shapefile in the app completes without throwing any exceptions.

Less tedious to perform than clicking manually! Just execute `mvn test` from the terminal, and you're golden.