### PR TITLE
Add shapefile integration test

### DIFF
--- a/src/main/java/org/nocrala/tools/gis/data/esri/shapefile/NocralaShapeFileReader.java
+++ b/src/main/java/org/nocrala/tools/gis/data/esri/shapefile/NocralaShapeFileReader.java
@@ -14,6 +14,7 @@ import org.nocrala.tools.gis.data.esri.shapefile.shape.ShapeHeader;
 import org.nocrala.tools.gis.data.esri.shapefile.shape.ShapeType;
 import org.nocrala.tools.gis.data.esri.shapefile.shape.shapes.*;
 import org.nocrala.tools.gis.data.esri.shapefile.util.ISUtil;
+import shapefile.ShapeFileReader;
 
 import java.io.BufferedInputStream;
 import java.io.EOFException;
@@ -27,7 +28,7 @@ import java.util.Arrays;
  * simple Java objects.
  * 
  */
-public class ShapeFileReader implements shapefile.ShapeFileReader {
+public class NocralaShapeFileReader implements ShapeFileReader {
 
   private BufferedInputStream is;
   private ValidationPreferences rules;
@@ -58,8 +59,8 @@ public class ShapeFileReader implements shapefile.ShapeFileReader {
    * @throws IOException
    *           if it's not possible to read from the InputStream.
    */
-  public ShapeFileReader(final InputStream is,
-      final ValidationPreferences preferences)
+  public NocralaShapeFileReader(final InputStream is,
+                                final ValidationPreferences preferences)
       throws InvalidShapeFileException, IOException {
     initialize(is, preferences);
   }

--- a/src/main/java/org/nocrala/tools/gis/data/esri/shapefile/shape/Const.java
+++ b/src/main/java/org/nocrala/tools/gis/data/esri/shapefile/shape/Const.java
@@ -1,11 +1,11 @@
 package org.nocrala.tools.gis.data.esri.shapefile.shape;
 
-import org.nocrala.tools.gis.data.esri.shapefile.ShapeFileReader;
+import org.nocrala.tools.gis.data.esri.shapefile.NocralaShapeFileReader;
 
 public class Const {
 
   public static final String PREFERENCES = "You can change the validation preferences using "
       + "the additional constructor of the "
-      + ShapeFileReader.class.getName()
+      + NocralaShapeFileReader.class.getName()
       + " class.";
 }

--- a/src/main/java/shapefile/NocralaShapeFileReaderFactory.java
+++ b/src/main/java/shapefile/NocralaShapeFileReaderFactory.java
@@ -1,6 +1,6 @@
 package shapefile;
 
-import org.nocrala.tools.gis.data.esri.shapefile.ShapeFileReader;
+import org.nocrala.tools.gis.data.esri.shapefile.NocralaShapeFileReader;
 import org.nocrala.tools.gis.data.esri.shapefile.ValidationPreferences;
 import org.nocrala.tools.gis.data.esri.shapefile.exception.InvalidShapeFileException;
 
@@ -8,13 +8,13 @@ import java.io.FileInputStream;
 import java.io.IOException;
 
 public class NocralaShapeFileReaderFactory {
-    public static ShapeFileReader createShapeFileReader(FileInputStream is) throws InvalidShapeFileException, IOException {
+    public static NocralaShapeFileReader createShapeFileReader(FileInputStream is) throws InvalidShapeFileException, IOException {
         ValidationPreferences prefs = new ValidationPreferences();
         prefs.setMaxNumberOfPointsPerShape(32650*4);
         prefs.setAllowUnlimitedNumberOfPointsPerShape(true);
         prefs.setAllowBadContentLength(true);
         prefs.setAllowBadRecordNumbers(true);
 
-        return new ShapeFileReader(is, prefs);
+        return new NocralaShapeFileReader(is, prefs);
     }
 }

--- a/src/main/java/shapefile/NocralaShapeFileReaderFactory.java
+++ b/src/main/java/shapefile/NocralaShapeFileReaderFactory.java
@@ -7,10 +7,10 @@ import org.nocrala.tools.gis.data.esri.shapefile.exception.InvalidShapeFileExcep
 import java.io.FileInputStream;
 import java.io.IOException;
 
-public class NocralaShapeFileReaderFactory {
-    public static NocralaShapeFileReader createShapeFileReader(FileInputStream is) throws InvalidShapeFileException, IOException {
+public class NocralaShapeFileReaderFactory implements ShapeFileReaderFactory {
+    public NocralaShapeFileReader createShapeFileReader(FileInputStream is) throws InvalidShapeFileException, IOException {
         ValidationPreferences prefs = new ValidationPreferences();
-        prefs.setMaxNumberOfPointsPerShape(32650*4);
+        prefs.setMaxNumberOfPointsPerShape(32650 * 4);
         prefs.setAllowUnlimitedNumberOfPointsPerShape(true);
         prefs.setAllowBadContentLength(true);
         prefs.setAllowBadRecordNumbers(true);

--- a/src/main/java/shapefile/ShapeFileReaderFactory.java
+++ b/src/main/java/shapefile/ShapeFileReaderFactory.java
@@ -1,0 +1,10 @@
+package shapefile;
+
+import org.nocrala.tools.gis.data.esri.shapefile.exception.InvalidShapeFileException;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+public interface ShapeFileReaderFactory {
+    ShapeFileReader createShapeFileReader(FileInputStream is) throws InvalidShapeFileException, IOException;
+}

--- a/src/main/java/ui/MainFrame.java
+++ b/src/main/java/ui/MainFrame.java
@@ -6,6 +6,7 @@ import geography.*;
 import new_metrics.Metrics;
 import shapefile.NocralaShapeFileReaderFactory;
 import shapefile.ShapeFileReader;
+import shapefile.ShapeFileReaderFactory;
 import solutions.*;
 import util.DataAndHeader;
 import util.FileUtil;
@@ -3692,7 +3693,7 @@ public class MainFrame extends JFrame implements iChangeListener, iDiscreteEvent
 
 	    try {
 			FileInputStream is = new FileInputStream(f);
-			ShapeFileReader r = NocralaShapeFileReaderFactory.createShapeFileReader(is);
+			ShapeFileReader r = new NocralaShapeFileReaderFactory().createShapeFileReader(is);
 
 			String dbfname = f.getAbsolutePath();//.getName();
 			dbfname = dbfname.substring(0,dbfname.length()-4)+".dbf";

--- a/src/test/java/shapefile/ShapeFileReaderFactoryTest.java
+++ b/src/test/java/shapefile/ShapeFileReaderFactoryTest.java
@@ -1,0 +1,65 @@
+package shapefile;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import dbf.DBFReader;
+import geography.FeatureCollection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.nocrala.tools.gis.data.esri.shapefile.exception.InvalidShapeFileException;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * This is really an integration test that mimics the call site of `ShapeFileReaderFactory`
+ * and makes sure that calling it in an implementation-agnostic fashion works.
+ */
+class ShapeFileReaderFactoryTest {
+
+    private ShapeFileReaderFactory systemUnderTest;
+    private File sampleShpFile;
+    private File sampleDbfFile;
+
+    @BeforeEach
+    void setUp() {
+        // TODO: replace with the eventual factory class that replaces the Nocrala shapefile reader implementation
+        systemUnderTest = new NocralaShapeFileReaderFactory();
+        File sampleDataDirectory = new File("data/sample/Portland_City_Council_Districts");
+        String shapeFileRootName = "Portland_City_Council_Districts";
+        sampleShpFile = new File(sampleDataDirectory, shapeFileRootName + ".shp");
+        sampleDbfFile = new File(sampleDataDirectory, shapeFileRootName + ".dbf");
+    }
+
+    @Test
+    void createShapeFileReader() throws IOException {
+        try (FileInputStream fileInputStream = new FileInputStream(sampleShpFile)) {
+
+            // make sure we can read the file in without anything blowing up
+            ShapeFileReader shapeFileReader = systemUnderTest.createShapeFileReader(fileInputStream);
+
+            // test the reading of the header shape type
+            assertThat(shapeFileReader.getHeaderShapeType()).isEqualTo("POLYGON");
+
+            // make sure we can read the columns and data in the file
+            DBFReader dbfreader = new DBFReader(new FileInputStream(sampleDbfFile));
+            String[] cols = new String[dbfreader.getFieldCount()];
+            IntStream.range(0, cols.length).forEach(i -> {
+                cols[i] = dbfreader.getField(i).name;
+            });
+            int total = shapeFileReader.processShapeFile(cols, dbfreader, new FeatureCollection());
+            assertThat(total).isEqualTo(4);
+
+        } catch (IOException ioe) {
+            fail(ioe.getMessage());
+            throw ioe;
+        } catch (Exception e) {
+            fail(e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
This integration test mimics the current call site for `ShapeFileReaderFactory` and gets us in a good place for swapping out the current implementation with a different one.

This PR also includes a bit of refactoring: it extracts an interface for `NocralaShapeFileReaderFactory`, again so that we can easily swap out Nocrala for some other implementation, which we will bring in via the package manager and remove the Nocrala code from the codebase.